### PR TITLE
fix: bad renaming of handleKeyBoard + ESC key doesnt trigger errors anymore

### DIFF
--- a/demos/demo_5.lua
+++ b/demos/demo_5.lua
@@ -38,7 +38,7 @@ function patch.patchControls()
 		patch.hang = not patch.hang
 	end
 	-- fallback to general controls callback
-	controls.handleGeneralControls()
+	controls.handleKeyBoard()
 end
 
 

--- a/lib/cmdmenu.lua
+++ b/lib/cmdmenu.lua
@@ -23,9 +23,15 @@ CmdMenu.commands = {
 --- @public handleCmdMenu cmd menu handler
 function CmdMenu.handleCmdMenu()
 	CmdMenu.isOpen = (not CmdMenu.isOpen)
-	if CmdMenu.isOpen then patch.draw = CmdMenu.update else patch.draw = patch.defaultDraw end
-	-- clear cmd buffer, regardless
-	patch.canvases.cmd:renderTo(love.graphics.clear)
+	if patch then
+		if CmdMenu.isOpen then
+			patch.draw = CmdMenu.update
+		else
+			patch.draw = patch.defaultDraw
+		end
+		-- clear cmd buffer, regardless
+		patch.canvases.cmd:renderTo(love.graphics.clear)
+	end
 end
 
 --- @public textinput called when a key for text is pressed

--- a/lib/controls.lua
+++ b/lib/controls.lua
@@ -53,7 +53,7 @@ local function handleShaderCommands(slot)
 	return s
 end
 
---- @public handleGeneralControls 
+--- @public handleKeyBoard 
 --- Main function to handle general keyboard controls (patch-independent)
 function controls.handleKeyBoard()
 	-- handle command menu


### PR DESCRIPTION
Changed `handleGeneralControls` to `handleKeyBoard`, and `patch` value must exists

Close #3 

Close #5 