### PR TITLE
Add clone with submodules in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ Moreover, it supports advanced functionalities such as:
 
 
 ## Setup
-- [LÖVE](https://love2d.org/) version 11.4+
+- Install [LÖVE](https://love2d.org/) version 11.4+
 - Add LOVE2D bin folder to your PATH variable
-- Download/clone this repository.
+- Clone this repository, with all submodules, by running
+```
+git clone --recurse-submodules git@github.com:merumerutho/LOVJ.git
+```
 - From this repo main folder (containing the main.lua script), run:
 ```sh
 love .


### PR DESCRIPTION
In the original readme it wasn't clear that submodules were present. In this version, we explicitly tell the user to clone with all submodules.
