### PR TITLE
FFmpeg video sampler, databending, glitch FX, Spout rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+*.dll
 dynlib/
 
 # Studio web app build artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-*.dll
+dynlib/
 
 # Studio web app build artifacts
 studio/node_modules/

--- a/cfg/cfg_patches.lua
+++ b/cfg/cfg_patches.lua
@@ -9,7 +9,7 @@ local cfg_patches = {}
 cfg_patches.selectedPatch = 1
 
 --- @public DEFAULT_PATCH default patch loaded at startup
-cfg_patches.defaultPatch = {"demos/demo23/source/demo_23"}
+cfg_patches.defaultPatch = {"demos/demo29/source/demo_29"}
 
 --- @public patches list of patches
 cfg_patches.patches = {
@@ -41,6 +41,7 @@ cfg_patches.patches = {
     "demos/demo26/source/demo_26",
     "demos/demo27/source/demo_27",
     "demos/demo28/source/demo_28",
+    "demos/demo29/source/demo_29",
 }
 
 

--- a/cfg/cfg_spout.lua
+++ b/cfg/cfg_spout.lua
@@ -23,11 +23,8 @@ cfg_spout.receiverHandles = {}
 
 function cfg_spout.updateCanvases()
 	for i=1,#cfg_spout.senderHandles do
-		for k,v in pairs(cfg_spout.senders) do
-			if cfg_spout.senderHandles[i].name == v.name then
-				cfg_spout.senderHandles[i].canvas = love.graphics.newCanvas(v.width, v.height)
-			end
-		end
+		local s = cfg_spout.senderHandles[i]
+		s.canvas = love.graphics.newCanvas(s.width, s.height)
 	end
 end
 

--- a/cfg/cfg_spout.lua
+++ b/cfg/cfg_spout.lua
@@ -24,7 +24,11 @@ cfg_spout.receiverHandles = {}
 function cfg_spout.updateCanvases()
 	for i=1,#cfg_spout.senderHandles do
 		local s = cfg_spout.senderHandles[i]
-		s.canvas = love.graphics.newCanvas(s.width, s.height)
+		if s.reinit then
+			s:reinit()
+		else
+			s.canvas = love.graphics.newCanvas(s.width, s.height)
+		end
 	end
 end
 

--- a/installFFmpeg.py
+++ b/installFFmpeg.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import os
+import platform
+import subprocess
+import sys
+import urllib.request
+import zipfile
+import tarfile
+
+URLS = {
+    "Windows": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip",
+    "Linux": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl-shared.tar.xz",
+}
+
+LIB_PREFIXES = ("avcodec", "avformat", "avutil", "swscale", "swresample")
+
+DEST_DIR = "dynlib"
+
+system = platform.system()
+
+
+def install_from_archive(url):
+    archive_name = url.rsplit("/", 1)[1]
+
+    print(f"Downloading FFmpeg shared libraries for {system}...")
+    urllib.request.urlretrieve(url, archive_name)
+
+    os.makedirs(DEST_DIR, exist_ok=True)
+
+    print("Extracting...")
+    if archive_name.endswith(".zip"):
+        with zipfile.ZipFile(archive_name) as zf:
+            for entry in zf.namelist():
+                basename = os.path.basename(entry)
+                if "/bin/" in entry and basename.endswith(".dll") and any(basename.startswith(p) for p in LIB_PREFIXES):
+                    dest = os.path.join(DEST_DIR, basename)
+                    with zf.open(entry) as src, open(dest, "wb") as dst:
+                        dst.write(src.read())
+                    print(f"  -> {dest}")
+    elif archive_name.endswith(".tar.xz"):
+        with tarfile.open(archive_name, "r:xz") as tf:
+            for member in tf.getmembers():
+                basename = os.path.basename(member.name)
+                if "/lib/" in member.name and any(basename.startswith("lib" + p) for p in LIB_PREFIXES) and ".so" in basename:
+                    dest = os.path.join(DEST_DIR, basename)
+                    with tf.extractfile(member) as src, open(dest, "wb") as dst:
+                        dst.write(src.read())
+                    print(f"  -> {dest}")
+
+    print("Cleaning up...")
+    os.remove(archive_name)
+
+
+def install_macos():
+    print("Installing FFmpeg via Homebrew...")
+    try:
+        subprocess.run(["brew", "--version"], check=True, capture_output=True)
+    except FileNotFoundError:
+        print("Homebrew not found. Install it from https://brew.sh then re-run this script.")
+        sys.exit(1)
+
+    subprocess.run(["brew", "install", "ffmpeg"], check=True)
+
+    os.makedirs(DEST_DIR, exist_ok=True)
+
+    brew_prefix = subprocess.run(["brew", "--prefix", "ffmpeg"], capture_output=True, text=True, check=True).stdout.strip()
+    lib_dir = os.path.join(brew_prefix, "lib")
+    for f in os.listdir(lib_dir):
+        if any(f.startswith("lib" + p) for p in LIB_PREFIXES) and f.endswith(".dylib") and not os.path.islink(os.path.join(lib_dir, f)):
+            src = os.path.join(lib_dir, f)
+            dest = os.path.join(DEST_DIR, f)
+            with open(src, "rb") as s, open(dest, "wb") as d:
+                d.write(s.read())
+            print(f"  -> {dest}")
+
+
+if system == "Darwin":
+    install_macos()
+elif system in URLS:
+    install_from_archive(URLS[system])
+else:
+    print(f"Unsupported platform: {system}")
+    sys.exit(1)
+
+print(f"Done. FFmpeg shared libraries installed in {DEST_DIR}/.")

--- a/installSpout.bat
+++ b/installSpout.bat
@@ -1,2 +1,0 @@
-curl -o SpoutLibrary.dll -L "https://github.com/leadedge/Spout2/raw/refs/heads/master/SPOUTSDK/SpoutLibrary/SpoutLibraryExample/bin/SpoutLibrary.dll"
-curl -o SpoutWrapper.dll -L "https://github.com/merumerutho/SpoutWrapper/releases/download/1.1.0/SpoutWrapper.dll"

--- a/installSpout.py
+++ b/installSpout.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import os
+import platform
+import sys
+import urllib.request
+
+if platform.system() != "Windows":
+    print("Spout is Windows-only (DirectX texture sharing). Skipping.")
+    sys.exit(0)
+
+DLLS = {
+    "SpoutLibrary.dll": "https://github.com/leadedge/Spout2/raw/refs/heads/master/SPOUTSDK/SpoutLibrary/SpoutLibraryExample/bin/SpoutLibrary.dll",
+    "SpoutWrapper.dll": "https://github.com/merumerutho/SpoutWrapper/releases/download/1.1.0/SpoutWrapper.dll",
+}
+
+os.makedirs("dynlib", exist_ok=True)
+
+for name, url in DLLS.items():
+    dest = os.path.join("dynlib", name)
+    print(f"Downloading {name}...")
+    urllib.request.urlretrieve(url, dest)
+    print(f"  -> {dest}")
+
+print("Done. Spout DLLs installed in dynlib/.")

--- a/installSpout.py
+++ b/installSpout.py
@@ -12,9 +12,8 @@ if platform.system() != "Windows":
 SPOUT_URL = "https://github.com/leadedge/Spout2/releases/download/2.007.017/Spout-SDK-binaries_2-007-017_1.zip"
 SPOUT_ZIP = "spout-sdk.zip"
 SPOUT_BIN_DIR = "Spout-SDK-binaries/Libs_2-007-017/MD/bin"
-WRAPPER_URL = "https://github.com/merumerutho/SpoutWrapper/releases/download/1.1.0/SpoutWrapper.dll"
-
 DEST_DIR = "dynlib"
+
 os.makedirs(DEST_DIR, exist_ok=True)
 
 print("Downloading Spout SDK...")
@@ -32,9 +31,4 @@ with zipfile.ZipFile(SPOUT_ZIP) as zf:
 
 os.remove(SPOUT_ZIP)
 
-print("Downloading SpoutWrapper.dll...")
-dest = os.path.join(DEST_DIR, "SpoutWrapper.dll")
-urllib.request.urlretrieve(WRAPPER_URL, dest)
-print(f"  -> {dest}")
-
-print("Done. Spout DLLs installed in dynlib/.")
+print("Done. SpoutLibrary.dll installed in dynlib/.")

--- a/installSpout.py
+++ b/installSpout.py
@@ -3,22 +3,38 @@ import os
 import platform
 import sys
 import urllib.request
+import zipfile
 
 if platform.system() != "Windows":
     print("Spout is Windows-only (DirectX texture sharing). Skipping.")
     sys.exit(0)
 
-DLLS = {
-    "SpoutLibrary.dll": "https://github.com/leadedge/Spout2/raw/refs/heads/master/SPOUTSDK/SpoutLibrary/SpoutLibraryExample/bin/SpoutLibrary.dll",
-    "SpoutWrapper.dll": "https://github.com/merumerutho/SpoutWrapper/releases/download/1.1.0/SpoutWrapper.dll",
-}
+SPOUT_URL = "https://github.com/leadedge/Spout2/releases/download/2.007.017/Spout-SDK-binaries_2-007-017_1.zip"
+SPOUT_ZIP = "spout-sdk.zip"
+SPOUT_BIN_DIR = "Spout-SDK-binaries/Libs_2-007-017/MD/bin"
+WRAPPER_URL = "https://github.com/merumerutho/SpoutWrapper/releases/download/1.1.0/SpoutWrapper.dll"
 
-os.makedirs("dynlib", exist_ok=True)
+DEST_DIR = "dynlib"
+os.makedirs(DEST_DIR, exist_ok=True)
 
-for name, url in DLLS.items():
-    dest = os.path.join("dynlib", name)
-    print(f"Downloading {name}...")
-    urllib.request.urlretrieve(url, dest)
-    print(f"  -> {dest}")
+print("Downloading Spout SDK...")
+urllib.request.urlretrieve(SPOUT_URL, SPOUT_ZIP)
+
+print("Extracting SpoutLibrary.dll...")
+with zipfile.ZipFile(SPOUT_ZIP) as zf:
+    for entry in zf.namelist():
+        basename = os.path.basename(entry)
+        if entry.startswith(SPOUT_BIN_DIR) and basename == "SpoutLibrary.dll":
+            dest = os.path.join(DEST_DIR, basename)
+            with zf.open(entry) as src, open(dest, "wb") as dst:
+                dst.write(src.read())
+            print(f"  -> {dest}")
+
+os.remove(SPOUT_ZIP)
+
+print("Downloading SpoutWrapper.dll...")
+dest = os.path.join(DEST_DIR, "SpoutWrapper.dll")
+urllib.request.urlretrieve(WRAPPER_URL, dest)
+print(f"  -> {dest}")
 
 print("Done. Spout DLLs installed in dynlib/.")

--- a/lib/savemgr.lua
+++ b/lib/savemgr.lua
@@ -99,10 +99,6 @@ function saveMgr.loadPatch(patchName, slot)
 	-- Re-bind this slot to lick so subsequent edits to the new patch file
 	-- trigger a rebuild targeting this slot.
 	if bindPatchSlot then bindPatchSlot(slot) end
-	-- for debugging
-	--print("global settings: " .. tostring(globalSettings))
-	--print("shaderext: " .. tostring(patchSlots[slot].shaderext))
-	--print("parameters: " .. tostring(patchSlots[slot].patch.resources.parameters))
 end
 
 

--- a/lib/spout.lua
+++ b/lib/spout.lua
@@ -52,15 +52,19 @@ local vtable_types = {
 	GetSenderWidth    = ffi.typeof("unsigned int (__thiscall *)(SPOUTLIBRARY*)"),
 	GetSenderHeight   = ffi.typeof("unsigned int (__thiscall *)(SPOUTLIBRARY*)"),
 	GetSenderFrame    = ffi.typeof("long (__thiscall *)(SPOUTLIBRARY*)"),
+	ReleaseSender     = ffi.typeof("void (__thiscall *)(SPOUTLIBRARY*, unsigned int)"),
+	ReleaseReceiver   = ffi.typeof("void (__thiscall *)(SPOUTLIBRARY*)"),
 }
 
 -- Vtable slot indices (from SpoutLibrary.h declaration order)
 local vtable_slots = {
 	SetSenderName     = 0,
+	ReleaseSender     = 2,
 	SendFbo           = 3,
 	SendTexture       = 4,
 	SendImage         = 5,
 	SetReceiverName   = 16,
+	ReleaseReceiver   = 18,
 	ReceiveImage      = 20,
 	IsUpdated         = 21,
 	IsConnected       = 22,
@@ -132,7 +136,25 @@ function spout.SpoutSender:init()
 	self.spoutLib = ffi.load("dynlib/SpoutLibrary.dll")
 	self.handle = self.spoutLib.GetSpout()
 	vtable_call(self.handle, "SetSenderName")(self.handle, name)
+	self.canvas = love.graphics.newCanvas(self.width, self.height)
 	logInfo("SPOUT SENDER initialized: " .. name)
+end
+
+function spout.SpoutSender:reinit()
+	if not self.spoutLib then
+		self.canvas = love.graphics.newCanvas(self.width, self.height)
+		return
+	end
+	if self.handle then
+		pcall(function()
+			vtable_call(self.handle, "ReleaseSender")(self.handle, 0)
+		end)
+	end
+	self.handle = self.spoutLib.GetSpout()
+	vtable_call(self.handle, "SetSenderName")(self.handle, self.name)
+	self.canvas = love.graphics.newCanvas(self.width, self.height)
+	self.textureId = 0
+	logInfo("SPOUT SENDER reinitialized: " .. self.name)
 end
 
 function spout.SpoutReceiver:init()

--- a/lib/spout.lua
+++ b/lib/spout.lua
@@ -117,7 +117,7 @@ end
 --- Initialize SpoutSender with associated Canvas / Texture
 function spout.SpoutSender:init()
 	local name = self.name
-	self.handle = ffi.load("SpoutWrapper.dll")
+	self.handle = ffi.load("dynlib/SpoutWrapper.dll")
 	-- Transcribe sender name to memory
 	local senderNamePtr = ffi.cast('char *', self.nameMem:getFFIPointer())
 	for i=1,(#name) do
@@ -135,7 +135,7 @@ end
 function spout.SpoutReceiver:init()
 	local ptr
 	local name = self.name
-	self.handle = ffi.load("SpoutWrapper.dll")
+	self.handle = ffi.load("dynlib/SpoutWrapper.dll")
 
 	-- Transcribe receiver name to memory
 	local receiverNamePtr = ffi.cast('char *', self.nameMem:getFFIPointer())

--- a/lib/spout.lua
+++ b/lib/spout.lua
@@ -1,6 +1,7 @@
 -- spout.lua
 --
 -- Interfacing with spout library for video texture sharing (server/client)
+-- Calls SpoutLibrary.dll directly via C++ vtable (no SpoutWrapper needed)
 
 local spout = {}
 
@@ -14,56 +15,73 @@ local drawingUtils = lovjRequire("lib/utils/drawing")
 local cfgScreen = lovjRequire("cfg/cfg_screen")
 
 ffi.cdef[[
-	void SetSenderNameWrapper(const char* senderName);
-	bool SendImageWrapper(const unsigned char* pixels, unsigned int width, unsigned int height, unsigned int glFormat, bool bInvert);
-	bool SendTextureWrapper(unsigned int TextureID, unsigned int TextureTarget, unsigned int width, unsigned int height, bool bInvert, unsigned int HostFbo);
-	bool SendFboWrapper(unsigned int fboId, unsigned int width, unsigned int height, bool bInvert);
-	void SetReceiverNameWrapper(const char * SenderName);
-	bool IsConnectedWrapper();
-	bool IsUpdatedWrapper();
-	bool IsFrameNewWrapper();
-	unsigned int GetSenderWidthWrapper();
-	unsigned int GetSenderHeightWrapper();
-	long GetSenderFrameWrapper();
-	const char * GetSenderNameWrapper();
-	bool ReceiveImageWrapper(const unsigned char* pixels, unsigned int glFormat, bool bInvert, unsigned int hostFbo);
+	typedef struct SPOUTLIBRARY SPOUTLIBRARY;
+	typedef SPOUTLIBRARY* SPOUTHANDLE;
+	SPOUTHANDLE __stdcall GetSpout(void);
+
+	// OpenGL types for framebuffer queries
+	typedef uint32_t GLuint;
+	typedef int32_t GLint;
+	typedef uint32_t GLenum;
+	void glGetFramebufferAttachmentParameteriv(GLenum target, GLenum attachment,
+	                                           GLenum pname, GLint *params);
+	typedef void (*type_glGetFramebufferAttachmentParameteriv)(GLenum target, GLenum attachment,
+	                                                           GLenum pname, GLint *params);
+
+	typedef const char CHAR;
+	typedef CHAR *LPSTR;
+	typedef LPSTR LPCSTR;
+	typedef void VOID;
+	typedef VOID *LPVOID;
+	typedef LPVOID PROC;
+	PROC wglGetProcAddress(LPCSTR lpszProc);
 ]]
 
--- credits to RNavega for the trick on getting the canvas texture id and pointer
--- and to s-ol for showing me this clever hack
--- https://love2d.org/forums/viewtopic.php?t=96388
+-- Vtable method types for the functions we use
+local vtable_types = {
+	SetSenderName     = ffi.typeof("void (__thiscall *)(SPOUTLIBRARY*, const char*)"),
+	SendTexture       = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*, unsigned int, unsigned int, unsigned int, unsigned int, bool, unsigned int)"),
+	SendImage         = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*, const unsigned char*, unsigned int, unsigned int, unsigned int, bool)"),
+	SendFbo           = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*, unsigned int, unsigned int, unsigned int, bool)"),
+	SetReceiverName   = ffi.typeof("void (__thiscall *)(SPOUTLIBRARY*, const char*)"),
+	ReceiveImage      = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*, unsigned char*, unsigned int, bool, unsigned int)"),
+	IsUpdated         = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*)"),
+	IsConnected       = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*)"),
+	IsFrameNew        = ffi.typeof("bool (__thiscall *)(SPOUTLIBRARY*)"),
+	GetSenderName     = ffi.typeof("const char* (__thiscall *)(SPOUTLIBRARY*)"),
+	GetSenderWidth    = ffi.typeof("unsigned int (__thiscall *)(SPOUTLIBRARY*)"),
+	GetSenderHeight   = ffi.typeof("unsigned int (__thiscall *)(SPOUTLIBRARY*)"),
+	GetSenderFrame    = ffi.typeof("long (__thiscall *)(SPOUTLIBRARY*)"),
+}
 
-ffi.cdef([[
-    // https://github.com/malkia/luajit-winapi/blob/master/ffi/winapi/headers/common.lua#L104C3-L106C32
-    // Cheating by making it 'const' or else LuaJIT doesn't do auto-conversion from a Lua string.
-    typedef const char CHAR;
-    typedef CHAR *LPSTR; //Pointer
-    typedef LPSTR LPCSTR; //Alias
+-- Vtable slot indices (from SpoutLibrary.h declaration order)
+local vtable_slots = {
+	SetSenderName     = 0,
+	SendFbo           = 3,
+	SendTexture       = 4,
+	SendImage         = 5,
+	SetReceiverName   = 16,
+	ReceiveImage      = 20,
+	IsUpdated         = 21,
+	IsConnected       = 22,
+	IsFrameNew        = 23,
+	GetSenderName     = 24,
+	GetSenderWidth    = 25,
+	GetSenderHeight   = 26,
+	GetSenderFrame    = 29,
+}
 
-    // https://github.com/malkia/luajit-winapi/blob/master/ffi/winapi/headers/common.lua#L28C3-L29C34
-    typedef void VOID; //Alias
-    typedef VOID *LPVOID; //Pointer
-    // https://github.com/malkia/luajit-winapi/blob/master/ffi/winapi/windows/opengl32.lua#L6
-    typedef LPVOID PROC; //Alias
-
-    // https://github.com/malkia/luajit-winapi/blob/master/ffi/winapi/windows/opengl32.lua#L54
-    PROC wglGetProcAddress(LPCSTR lpszProc);
-
-    typedef uint32_t GLuint;
-    typedef int32_t GLint;
-    typedef uint32_t GLenum;
-    void glGetFramebufferAttachmentParameteriv(GLenum target, GLenum attachment,
-                                               GLenum pname, GLint *params);
-    typedef void (*type_glGetFramebufferAttachmentParameteriv)(GLenum target, GLenum attachment,
-                                                               GLenum pname, GLint *params);
-]])
+-- Read a vtable function pointer from a C++ object
+local function vtable_call(obj, name)
+	local vt = ffi.cast("void***", obj)[0]
+	local slot = vtable_slots[name]
+	local fn = ffi.cast(vtable_types[name], vt[slot])
+	return fn
+end
 
 
 local TYPEOF_GLINT_PTR = ffi.typeof('GLint[1]')
-local SDL = (jit.os == "Windows") and ffi.load("SDL2") or ffi.C
 
--- OpenGL binding from malkia's UFO:
--- https://github.com/malkia/ufo/blob/master/ffi/OpenGL.lua
 local libs = ffi_OpenGL_libs or {
 	OSX     = { x86 = "OpenGL.framework/OpenGL", x64 = "OpenGL.framework/OpenGL" },
 	Windows = { x86 = "OPENGL32.DLL",            x64 = "OPENGL32.DLL" },
@@ -76,7 +94,6 @@ local gl = ffi.load(libs[ffi.os][ffi.arch])
 local proc = gl.wglGetProcAddress('glGetFramebufferAttachmentParameteriv')
 local glGetFramebufferAttachmentParameteriv = ffi.cast('type_glGetFramebufferAttachmentParameteriv', proc)
 
--- https://github.com/KhronosGroup/OpenGL-Registry/blob/main/api/GLES2/gl2.h
 local GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8CD1
 local GL_COLOR_ATTACHMENT0 = 0x8CE0
 local GL_FRAMEBUFFER = 0x8D40
@@ -87,111 +104,74 @@ local GL_RGBA = 0x1908
 spout.SpoutSender = {}
 spout.SpoutReceiver = {}
 
---- @public spout.SpoutSender:new
---- Create a new SpoutSender
 function spout.SpoutSender:new(o, name, w, h)
 	local o = {} or o
 	setmetatable(o, self)
 	self.__index = self
 	o.name = name
 	o.width, o.height = w, h
-	o.nameMem = love.data.newByteData(2^8)
 	o.textureId = 0
 	o.canvas = love.graphics.newCanvas(w, h)
 	return o
 end
 
---- @public spout.SpoutReceiver:new
---- Create a new SpoutReceiver
 function spout.SpoutReceiver:new(o, name)
 	local o = {} or o
 	setmetatable(o, self)
 	self.__index = self
 	o.name = name
-	o.nameMem = love.data.newByteData(2^8)
 	o.connected = false
 	return o
 end
 
---- @public spout.SpoutSender:init
---- Initialize SpoutSender with associated Canvas / Texture
 function spout.SpoutSender:init()
 	local name = self.name
-	self.handle = ffi.load("dynlib/SpoutWrapper.dll")
-	-- Transcribe sender name to memory
-	local senderNamePtr = ffi.cast('char *', self.nameMem:getFFIPointer())
-	for i=1,(#name) do
-		senderNamePtr[i-1] = string.byte(name:sub(i,i))
-	end
-	-- Add termination character
-	senderNamePtr[#name] = string.byte('\0')
-	self.handle.SetSenderNameWrapper(senderNamePtr)
-	-- Done
+	self.spoutLib = ffi.load("dynlib/SpoutLibrary.dll")
+	self.handle = self.spoutLib.GetSpout()
+	vtable_call(self.handle, "SetSenderName")(self.handle, name)
 	logInfo("SPOUT SENDER initialized: " .. name)
 end
 
---- @public spout.SpoutReceiver:init
---- Initialize SpoutReceiver
 function spout.SpoutReceiver:init()
-	local ptr
 	local name = self.name
-	self.handle = ffi.load("dynlib/SpoutWrapper.dll")
+	self.spoutLib = ffi.load("dynlib/SpoutLibrary.dll")
+	self.handle = self.spoutLib.GetSpout()
+	vtable_call(self.handle, "SetReceiverName")(self.handle, name)
 
-	-- Transcribe receiver name to memory
-	local receiverNamePtr = ffi.cast('char *', self.nameMem:getFFIPointer())
-	for i=1,(#name) do
-		receiverNamePtr[i-1] = string.byte(name:sub(i,i))
-	end
-	-- Add termination character
-	receiverNamePtr[#name] = string.byte('\0')
-
-	-- Set name
-	self.handle.SetReceiverNameWrapper(receiverNamePtr)
-
-	-- Handle first reception
-	self.handle.ReceiveImageWrapper(ptr, GL_RGBA, false, 0)
-	if (self.handle.IsUpdatedWrapper()) then
-		self.width = self.handle.GetSenderWidthWrapper()
-		self.height = self.handle.GetSenderHeightWrapper()
-		-- Allocate img data and pointer
+	vtable_call(self.handle, "ReceiveImage")(self.handle, nil, GL_RGBA, false, 0)
+	if vtable_call(self.handle, "IsUpdated")(self.handle) then
+		self.width = vtable_call(self.handle, "GetSenderWidth")(self.handle)
+		self.height = vtable_call(self.handle, "GetSenderHeight")(self.handle)
+		if self.width == 0 or self.height == 0 then return end
 		self.data = love.data.newByteData(4 * self.width * self.height)
 		self.dataPtr = ffi.cast('const char *', self.data:getFFIPointer())
-		-- Set receiver as 'connected'
 		self.connected = true
-		local name = self.handle.GetSenderNameWrapper()
-		self.senderName = ffi.string(name)
+		local sname = vtable_call(self.handle, "GetSenderName")(self.handle)
+		self.senderName = ffi.string(sname)
 		logInfo("SPOUT RECEIVER initialized: " .. self.senderName .. " - size: " .. self.width .. "x" .. self.height)
 	end
 end
 
---- @public spout.SpoutSender:SendCanvas
---- Send Canvas as Texture
 function spout.SpoutSender:SendCanvas(input_canvas, wf, hf)
-	wf = wf or 1  -- opt. arg
-	hf = hf or 1  -- opt. arg
-	-- Draw to self.canvas with correct scaling
+	wf = wf or 1
+	hf = hf or 1
 	self.textureId = self:getTextureId()
 	drawingUtils.clearCanvas(self.canvas)
 	drawingUtils.drawCanvasToCanvas(input_canvas, self.canvas, 0, 0, 0, wf, hf)
 	local cur_canvas = love.graphics.getCanvas()
 	love.graphics.setCanvas(self.canvas)
-	-- Send texture
 	if self.textureId then
-		-- Send picture
-		self.handle.SendTextureWrapper(self.textureId, GL_TEXTURE_2D, self.width, self.height, false, 0)
+		vtable_call(self.handle, "SendTexture")(self.handle, self.textureId, GL_TEXTURE_2D, self.width, self.height, false, 0)
 	end
 	love.graphics.setCanvas(cur_canvas)
-	return
 end
 
---- @private spout.SpoutReceiver:ReceiveImage
---- Receive Image
 function spout.SpoutReceiver:ReceiveImage()
 	local img = nil
 	local ret = false
-	if (self.connected == true) then
-		if (self.handle.IsFrameNewWrapper()) then
-			ret = self.handle.ReceiveImageWrapper(self.dataPtr, GL_RGBA, false, 0)
+	if self.connected then
+		if vtable_call(self.handle, "IsFrameNew")(self.handle) then
+			ret = vtable_call(self.handle, "ReceiveImage")(self.handle, ffi.cast("unsigned char*", self.dataPtr), GL_RGBA, false, 0)
 			if self.dataPtr ~= nil then
 				local imgData = love.image.newImageData(self.width, self.height, "rgba8", self.data)
 				img = love.graphics.newImage(imgData)
@@ -201,35 +181,25 @@ function spout.SpoutReceiver:ReceiveImage()
 	return ret, img
 end
 
---- @public spout.SpoutReceiver:draw
---- If connected, perform ReceiveImage
 function spout.SpoutReceiver:draw()
-	-- default dummy picture
-    local dummy_imgData = love.graphics.newImageData(1,1, "rgba8", {0,0,0,0})
-    local img = love.grahpics.newImage(dummy_imgData)
+	local dummy_imgData = love.image.newImageData(1, 1, "rgba8", "\0\0\0\0")
+	local img = love.graphics.newImage(dummy_imgData)
 	local ret = false
-
-    -- Receive Image if connected
-    if (self.connected) then
-        ret, recv_img = self:ReceiveImage()
-        self.connected = ret -- update connection state
-        if ret then img = recv_img end
-    end
+	if self.connected then
+		ret, recv_img = self:ReceiveImage()
+		self.connected = ret
+		if ret then img = recv_img end
+	end
 	return img
 end
 
---- @public spout.SpoutReceiver:update
---- If disconnected, try connecting
 function spout.SpoutReceiver:update()
-	if (self.connected == false) then
+	if not self.connected then
 		self:init()
 	end
 end
 
---- @public spout.SpoutSender:getTextureId
---- Retrieve Texture ID from Canvas
 function spout.SpoutSender:getTextureId()
-	-- get texture ID 
 	local textureId = nil
 	local cur_canvas = love.graphics.getCanvas()
 	love.graphics.setCanvas(self.canvas)
@@ -239,7 +209,7 @@ function spout.SpoutSender:getTextureId()
 										GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
 										tempName)
 	textureId = tempName[0]
-	love.graphics.setCanvas(cur_canvas)  
+	love.graphics.setCanvas(cur_canvas)
 	return textureId
 end
 

--- a/lib/spout.lua
+++ b/lib/spout.lua
@@ -91,8 +91,11 @@ local libs = ffi_OpenGL_libs or {
 	Other   = { x86 = "libGL.so",                x64 = "libGL.so" },
 }
 local gl = ffi.load(libs[ffi.os][ffi.arch])
-local proc = gl.wglGetProcAddress('glGetFramebufferAttachmentParameteriv')
-local glGetFramebufferAttachmentParameteriv = ffi.cast('type_glGetFramebufferAttachmentParameteriv', proc)
+
+local function getGLFBAttachParam()
+	local p = gl.wglGetProcAddress('glGetFramebufferAttachmentParameteriv')
+	return ffi.cast('type_glGetFramebufferAttachmentParameteriv', p)
+end
 
 local GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8CD1
 local GL_COLOR_ATTACHMENT0 = 0x8CE0
@@ -204,10 +207,11 @@ function spout.SpoutSender:getTextureId()
 	local cur_canvas = love.graphics.getCanvas()
 	love.graphics.setCanvas(self.canvas)
 	local tempName = TYPEOF_GLINT_PTR()
-	glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER,
-										GL_COLOR_ATTACHMENT0,
-										GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
-										tempName)
+	local glFunc = getGLFBAttachParam()
+	glFunc(GL_FRAMEBUFFER,
+		   GL_COLOR_ATTACHMENT0,
+		   GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
+		   tempName)
 	textureId = tempName[0]
 	love.graphics.setCanvas(cur_canvas)
 	return textureId

--- a/lib/video/databender.lua
+++ b/lib/video/databender.lua
@@ -1,0 +1,193 @@
+local ffi = require("ffi")
+local bit = require("bit")
+
+local AV_PKT_FLAG_KEY = 0x0001
+
+local DataBender = {}
+DataBender.__index = DataBender
+
+function DataBender:new()
+    math.randomseed(os.time())
+    return setmetatable({
+        mode = "off",
+        intensity = 0.5,
+        frameCount = 0,
+        lastPFrameData = nil,
+        lastPFrameSize = 0,
+        meltCounter = 0,
+        bloomRepeatCount = 0,
+        hadFirstKeyframe = false,
+    }, self)
+end
+
+function DataBender:setMode(mode)
+    if mode ~= self.mode then
+        print("[DataBender] mode: " .. tostring(mode))
+        self.mode = mode
+        self.frameCount = 0
+        self.meltCounter = 0
+        self.bloomRepeatCount = 0
+        self.lastPFrameData = nil
+        self.lastPFrameSize = 0
+        self.hadFirstKeyframe = false
+    end
+end
+
+function DataBender:onSeek()
+    self.hadFirstKeyframe = false
+end
+
+function DataBender:setIntensity(intensity)
+    self.intensity = math.max(0, intensity)
+end
+
+function DataBender:isKeyframe(packet)
+    return bit.band(packet.flags, AV_PKT_FLAG_KEY) ~= 0
+end
+
+function DataBender:processPacket(packet)
+    if self.mode == "off" then return "decode" end
+
+    self.frameCount = self.frameCount + 1
+
+    if self.mode == "melt" then
+        return self:_melt(packet)
+    elseif self.mode == "crush" then
+        return self:_crush(packet)
+    elseif self.mode == "corrupt" then
+        return self:_corrupt(packet)
+    elseif self.mode == "bloom" then
+        return self:_bloom(packet)
+    end
+
+    return "decode"
+end
+
+--- Melt: remove I-frames so P-frames apply deltas to stale references.
+--- At intensity 1, ~50 keyframes skipped before reset. No upper clamp.
+function DataBender:_melt(packet)
+    if self:isKeyframe(packet) then
+        if not self.hadFirstKeyframe then
+            self.hadFirstKeyframe = true
+            return "decode"
+        end
+        self.meltCounter = self.meltCounter + 1
+        local skipCount = math.max(1, math.floor(self.intensity * 200))
+        if self.meltCounter > skipCount then
+            self.meltCounter = 0
+            return "decode"
+        end
+        return "skip"
+    end
+    return "decode"
+end
+
+--- Crush: corrupt I-frame data so the decoder builds a garbled reference,
+--- then P-frames apply motion deltas on top of the garbage.
+function DataBender:_crush(packet)
+    if self:isKeyframe(packet) then
+        if not self.hadFirstKeyframe then
+            self.hadFirstKeyframe = true
+            return "decode"
+        end
+        self.meltCounter = self.meltCounter + 1
+        local skipCount = math.max(1, math.floor(self.intensity * 50))
+        if self.meltCounter > skipCount then
+            self.meltCounter = 0
+            return "decode"
+        end
+        if packet.size > 32 then
+            local start = 16
+            local range = packet.size - start
+            local numCorrupt = math.max(1, math.floor(range * 0.3 * math.min(self.intensity, 1)))
+            for i = 1, numCorrupt do
+                local pos = start + math.random(0, range - 1)
+                packet.data[pos] = 0
+            end
+        end
+        return "decode"
+    end
+    return "decode"
+end
+
+--- Corrupt: copy/shift memory blocks within the packet data.
+--- Produces macro-block displacement artifacts rather than random noise.
+--- Only touches non-keyframe packets to avoid decoder crashes.
+function DataBender:_corrupt(packet)
+    if packet.size < 64 then return "decode" end
+    if self:isKeyframe(packet) then return "decode" end
+
+    local safeOffset = 16
+    local range = packet.size - safeOffset
+    if range < 32 then return "decode" end
+
+    local numOps = math.max(1, math.floor(self.intensity * 8))
+    local maxBlock = math.max(8, math.min(math.floor(range / 2), math.floor(self.intensity * 256)))
+
+    pcall(function()
+        for i = 1, numOps do
+            local op = math.random(1, 3)
+            if op == 1 then
+                local blockSize = math.random(8, maxBlock)
+                local src = safeOffset + math.random(0, range - blockSize - 1)
+                local dst = safeOffset + math.random(0, range - blockSize - 1)
+                ffi.copy(packet.data + dst, packet.data + src, blockSize)
+            elseif op == 2 then
+                local blockSize = math.random(16, maxBlock)
+                local pos = safeOffset + math.random(0, range - blockSize - 1)
+                local shift = math.random(1, math.min(math.floor(self.intensity * 64), blockSize))
+                ffi.C.memmove(packet.data + pos + shift, packet.data + pos, blockSize - shift)
+            else
+                local patternPos = safeOffset + math.random(0, range - 5)
+                local fillSize = math.random(4, math.min(maxBlock, range - (patternPos - safeOffset)))
+                local byte = packet.data[patternPos]
+                ffi.fill(packet.data + patternPos, fillSize, byte)
+            end
+        end
+    end)
+
+    return "decode"
+end
+
+--- Bloom: re-send the same P-frame repeatedly for pixel streak effects.
+--- Bloom: skip I-frames (like melt) AND repeat the same P-frame.
+--- The repeated motion vectors accumulate on a stale reference,
+--- creating progressive pixel streaking/bleeding.
+function DataBender:_bloom(packet)
+    if self:isKeyframe(packet) then
+        if not self.hadFirstKeyframe then
+            self.hadFirstKeyframe = true
+            return "decode"
+        end
+        -- Skip I-frames so the reference stays stale
+        return "skip"
+    end
+
+    -- Capture first P-frame we see
+    if not self.lastPFrameData then
+        self.lastPFrameData = ffi.new("uint8_t[?]", packet.size)
+        ffi.copy(self.lastPFrameData, packet.data, packet.size)
+        self.lastPFrameSize = packet.size
+        self.bloomRepeatCount = 0
+        return "decode"
+    end
+
+    self.bloomRepeatCount = self.bloomRepeatCount + 1
+    local repeatTarget = math.max(2, math.floor(self.intensity * 60))
+
+    if self.bloomRepeatCount < repeatTarget then
+        -- Overwrite this packet with the captured P-frame's data
+        local copySize = math.min(self.lastPFrameSize, packet.size)
+        ffi.copy(packet.data, self.lastPFrameData, copySize)
+        return "decode"
+    else
+        -- Capture a new P-frame
+        self.lastPFrameData = ffi.new("uint8_t[?]", packet.size)
+        ffi.copy(self.lastPFrameData, packet.data, packet.size)
+        self.lastPFrameSize = packet.size
+        self.bloomRepeatCount = 0
+        return "decode"
+    end
+end
+
+return DataBender

--- a/lib/video/decode_thread.lua
+++ b/lib/video/decode_thread.lua
@@ -1,5 +1,6 @@
 require("love.data")
 require("love.timer")
+print("[decode_thread] starting...")
 local ffi = require("ffi")
 
 local sourcePath, cmdChannel, frameChannel, recycleChannel = ...
@@ -7,6 +8,11 @@ local sourcePath, cmdChannel, frameChannel, recycleChannel = ...
 -- Set up package path so we can require project modules
 package.path = sourcePath .. "/?.lua;" .. package.path
 local ff = require("lib.video.ffmpeg_ffi")
+local DataBender = require("lib.video.databender")
+local bender = DataBender:new()
+
+-- Suppress FFmpeg's error concealment warnings
+ff.avutil.av_log_set_level(ff.AV_LOG_FATAL)
 
 local fmtCtx, codecCtx, swsCtx, frame, packet
 local streamIdx, timeBase, width, height, duration, frameDuration
@@ -77,12 +83,41 @@ local function openVideo(path)
     timeBase = stream.time_base
     width = codecpar.width
     height = codecpar.height
-    duration = tonumber(fmtCtx.duration) / ff.AV_TIME_BASE
-    frameDuration = (timeBase.num > 0 and timeBase.den > 0)
-        and timeBase.num / timeBase.den or 1 / 30
+    -- Get duration: read raw bytes at the known offset for AVFormatContext.duration
+    -- Our struct definition has wrong offsets, so read it manually via pointer arithmetic
+    duration = 0
+    local ok, dur = pcall(function()
+        local p = ffi.cast("char*", fmtCtx)
+        -- Try reading int64 at several likely offsets for duration
+        for _, offset in ipairs({72, 80, 88, 96, 104}) do
+            local val = tonumber(ffi.cast("int64_t*", p + offset)[0])
+            local secs = val / ff.AV_TIME_BASE
+            if secs > 1 and secs < 100000 then
+                return secs
+            end
+        end
+        return 0
+    end)
+    if ok and dur > 0 then duration = dur end
+    print("[decode_thread] duration=" .. tostring(duration) .. "s")
+    -- Frame duration: use 1/30 as default. Refined from first two
+    -- decoded frames once playback starts.
+    frameDuration = 1 / 30
+    frameDurationProbed = false
 
     codecCtx = ff.avcodec.avcodec_alloc_context3(codecPtr[0])
     ff.avcodec.avcodec_parameters_to_context(codecCtx, codecpar)
+
+    -- Disable all error recovery and correction
+    pcall(function()
+        ff.avutil.av_opt_set(codecCtx, "flags", "+output_corrupt", 0)
+        ff.avutil.av_opt_set(codecCtx, "flags2", "+showall", 0)
+        ff.avutil.av_opt_set(codecCtx, "err_detect", "ignore_err", 0)
+        ff.avutil.av_opt_set(codecCtx, "ec", "0", 0)
+        ff.avutil.av_opt_set(codecCtx, "skip_loop_filter", "all", 0)
+        ff.avutil.av_opt_set(codecCtx, "skip_idct", "all", 0)
+    end)
+
     if ff.avcodec.avcodec_open2(codecCtx, codecPtr[0], nil) < 0 then
         frameChannel:push("error")
         frameChannel:push("failed to open codec")
@@ -123,7 +158,8 @@ local function decodeOneFrame(buf)
     local dstSlice = ffi.new("uint8_t*[4]", { dstPtr, nil, nil, nil })
     local dstStride = ffi.new("int[4]", { width * 4, 0, 0, 0 })
 
-    while true do
+    local maxAttempts = (bender.mode ~= "off") and 5 or 200
+    for attempt = 1, maxAttempts do
         local ret = ff.avformat.av_read_frame(fmtCtx, packet)
         if ret < 0 then
             ff.avcodec.av_packet_unref(packet)
@@ -131,25 +167,39 @@ local function decodeOneFrame(buf)
             return nil
         end
 
-        if packet.stream_index == streamIdx then
-            ret = ff.avcodec.avcodec_send_packet(codecCtx, packet)
+        if packet.stream_index ~= streamIdx then
             ff.avcodec.av_packet_unref(packet)
-            if ret < 0 then return nil end
-
-            ret = ff.avcodec.avcodec_receive_frame(codecCtx, frame)
-            if ret == 0 then
-                ff.swscale.sws_scale(swsCtx,
-                    ffi.cast("const uint8_t *const *", frame.data),
-                    frame.linesize, 0, height,
-                    dstSlice, dstStride)
-                local pts = ptsToSeconds(frame.pts)
-                lastDecodedPts = pts
-                return pts
-            end
         else
-            ff.avcodec.av_packet_unref(packet)
+            local action = bender:processPacket(packet)
+            if action == "skip" then
+                ff.avcodec.av_packet_unref(packet)
+            else
+                ret = ff.avcodec.avcodec_send_packet(codecCtx, packet)
+                ff.avcodec.av_packet_unref(packet)
+                -- On send error: skip this packet, keep trying
+                if ret < 0 then goto continue end
+
+                ret = ff.avcodec.avcodec_receive_frame(codecCtx, frame)
+                if ret == 0 then
+                    ff.swscale.sws_scale(swsCtx,
+                        ffi.cast("const uint8_t *const *", frame.data),
+                        frame.linesize, 0, height,
+                        dstSlice, dstStride)
+                    local pts = ptsToSeconds(frame.pts)
+                    if not frameDurationProbed and lastDecodedPts >= 0 and pts > lastDecodedPts then
+                        frameDuration = pts - lastDecodedPts
+                        frameDurationProbed = true
+                        print("[decode_thread] frameDuration=" .. tostring(frameDuration) .. "s")
+                    end
+                    lastDecodedPts = pts
+                    return pts
+                end
+                -- EAGAIN or other: need more packets, keep reading
+            end
         end
+        ::continue::
     end
+    return nil
 end
 
 local function seekTo(seconds)
@@ -157,7 +207,9 @@ local function seekTo(seconds)
     seconds = math.max(0, seconds)
     local ts = secondsToPts(seconds)
     ff.avformat.av_seek_frame(fmtCtx, streamIdx, ts, ff.AVSEEK_FLAG_BACKWARD)
-    ff.avcodec.avcodec_flush_buffers(codecCtx)
+    if bender.mode == "off" then
+        ff.avcodec.avcodec_flush_buffers(codecCtx)
+    end
     eof = false
     lastDecodedPts = -1
 end
@@ -180,6 +232,18 @@ while true do
             if state == "ready" then state = "playing" end
         elseif cmd == "pause" then
             if state == "playing" then state = "ready" end
+        elseif cmd == "bend_mode" then
+            local prevMode = bender.mode
+            local newMode = cmdChannel:demand()
+            bender:setMode(newMode)
+            -- Flush decoder when returning to normal mode to clear stale references
+            if prevMode ~= "off" and newMode == "off" and codecCtx ~= nil then
+                ff.avcodec.avcodec_flush_buffers(codecCtx)
+                lastDecodedPts = -1
+                frameChannel:push("flush")
+            end
+        elseif cmd == "bend_intensity" then
+            bender:setIntensity(cmdChannel:demand())
         elseif cmd == "quit" then
             cleanup()
             return
@@ -196,6 +260,10 @@ while true do
                 frameChannel:push("frame")
                 frameChannel:push(pts)
                 frameChannel:push(buf)
+                -- Throttle to video frame rate when bending to prevent speedup
+                if bender.mode ~= "off" then
+                    love.timer.sleep(frameDuration)
+                end
             else
                 recycleChannel:push(buf)
                 if eof then

--- a/lib/video/decode_thread.lua
+++ b/lib/video/decode_thread.lua
@@ -1,0 +1,211 @@
+require("love.data")
+require("love.timer")
+local ffi = require("ffi")
+
+local sourcePath, cmdChannel, frameChannel, recycleChannel = ...
+
+-- Set up package path so we can require project modules
+package.path = sourcePath .. "/?.lua;" .. package.path
+local ff = require("lib.video.ffmpeg_ffi")
+
+local fmtCtx, codecCtx, swsCtx, frame, packet
+local streamIdx, timeBase, width, height, duration, frameDuration
+local state = "idle"
+local speed = 1.0
+local targetPts = 0
+local lastDecodedPts = -1
+local eof = false
+
+local function cleanup()
+    if swsCtx ~= nil then
+        ff.swscale.sws_freeContext(swsCtx)
+        swsCtx = nil
+    end
+    if frame ~= nil then
+        local fp = ffi.new("AVFrame*[1]", { frame })
+        ff.avutil.av_frame_free(fp)
+        frame = nil
+    end
+    if packet ~= nil then
+        local pp = ffi.new("AVPacket*[1]", { packet })
+        ff.avcodec.av_packet_free(pp)
+        packet = nil
+    end
+    if codecCtx ~= nil then
+        local cp = ffi.new("AVCodecContext*[1]", { codecCtx })
+        ff.avcodec.avcodec_free_context(cp)
+        codecCtx = nil
+    end
+    if fmtCtx ~= nil then
+        local fp = ffi.new("AVFormatContext*[1]", { fmtCtx })
+        ff.avformat.avformat_close_input(fp)
+        fmtCtx = nil
+    end
+    state = "idle"
+end
+
+local function openVideo(path)
+    cleanup()
+
+    local fmtCtxPtr = ffi.new("AVFormatContext*[1]")
+    if ff.avformat.avformat_open_input(fmtCtxPtr, path, nil, nil) < 0 then
+        frameChannel:push("error")
+        frameChannel:push("failed to open " .. path)
+        return
+    end
+    fmtCtx = fmtCtxPtr[0]
+
+    if ff.avformat.avformat_find_stream_info(fmtCtx, nil) < 0 then
+        frameChannel:push("error")
+        frameChannel:push("failed to find stream info")
+        cleanup()
+        return
+    end
+
+    local codecPtr = ffi.new("const AVCodec*[1]")
+    streamIdx = ff.avformat.av_find_best_stream(
+        fmtCtx, ff.AVMEDIA_TYPE_VIDEO, -1, -1, codecPtr, 0)
+    if streamIdx < 0 then
+        frameChannel:push("error")
+        frameChannel:push("no video stream found")
+        cleanup()
+        return
+    end
+
+    local stream = fmtCtx.streams[streamIdx]
+    local codecpar = stream.codecpar
+    timeBase = stream.time_base
+    width = codecpar.width
+    height = codecpar.height
+    duration = tonumber(fmtCtx.duration) / ff.AV_TIME_BASE
+    frameDuration = (timeBase.num > 0 and timeBase.den > 0)
+        and timeBase.num / timeBase.den or 1 / 30
+
+    codecCtx = ff.avcodec.avcodec_alloc_context3(codecPtr[0])
+    ff.avcodec.avcodec_parameters_to_context(codecCtx, codecpar)
+    if ff.avcodec.avcodec_open2(codecCtx, codecPtr[0], nil) < 0 then
+        frameChannel:push("error")
+        frameChannel:push("failed to open codec")
+        cleanup()
+        return
+    end
+
+    swsCtx = ff.swscale.sws_getContext(
+        width, height, codecpar.format,
+        width, height, ff.AV_PIX_FMT_RGBA,
+        ff.SWS_BILINEAR, nil, nil, nil)
+
+    frame = ff.avutil.av_frame_alloc()
+    packet = ff.avcodec.av_packet_alloc()
+    lastDecodedPts = -1
+    eof = false
+
+    frameChannel:push("info")
+    frameChannel:push(width)
+    frameChannel:push(height)
+    frameChannel:push(duration)
+    frameChannel:push(frameDuration)
+
+    state = "ready"
+end
+
+local function ptsToSeconds(pts)
+    if pts == nil then return 0 end
+    return tonumber(pts) * timeBase.num / timeBase.den
+end
+
+local function secondsToPts(seconds)
+    return math.floor(seconds * timeBase.den / timeBase.num)
+end
+
+local function decodeOneFrame(buf)
+    local dstPtr = ffi.cast("uint8_t*", buf:getFFIPointer())
+    local dstSlice = ffi.new("uint8_t*[4]", { dstPtr, nil, nil, nil })
+    local dstStride = ffi.new("int[4]", { width * 4, 0, 0, 0 })
+
+    while true do
+        local ret = ff.avformat.av_read_frame(fmtCtx, packet)
+        if ret < 0 then
+            ff.avcodec.av_packet_unref(packet)
+            eof = true
+            return nil
+        end
+
+        if packet.stream_index == streamIdx then
+            ret = ff.avcodec.avcodec_send_packet(codecCtx, packet)
+            ff.avcodec.av_packet_unref(packet)
+            if ret < 0 then return nil end
+
+            ret = ff.avcodec.avcodec_receive_frame(codecCtx, frame)
+            if ret == 0 then
+                ff.swscale.sws_scale(swsCtx,
+                    ffi.cast("const uint8_t *const *", frame.data),
+                    frame.linesize, 0, height,
+                    dstSlice, dstStride)
+                local pts = ptsToSeconds(frame.pts)
+                lastDecodedPts = pts
+                return pts
+            end
+        else
+            ff.avcodec.av_packet_unref(packet)
+        end
+    end
+end
+
+local function seekTo(seconds)
+    if fmtCtx == nil then return end
+    seconds = math.max(0, seconds)
+    local ts = secondsToPts(seconds)
+    ff.avformat.av_seek_frame(fmtCtx, streamIdx, ts, ff.AVSEEK_FLAG_BACKWARD)
+    ff.avcodec.avcodec_flush_buffers(codecCtx)
+    eof = false
+    lastDecodedPts = -1
+end
+
+-- Main loop
+while true do
+    -- Process all pending commands
+    local cmd = cmdChannel:pop()
+    while cmd do
+        if cmd == "open" then
+            local path = cmdChannel:demand()
+            openVideo(path)
+        elseif cmd == "seek" then
+            local seconds = cmdChannel:demand()
+            seekTo(seconds)
+            frameChannel:push("flush")
+        elseif cmd == "speed" then
+            speed = cmdChannel:demand()
+        elseif cmd == "play" then
+            if state == "ready" then state = "playing" end
+        elseif cmd == "pause" then
+            if state == "playing" then state = "ready" end
+        elseif cmd == "quit" then
+            cleanup()
+            return
+        end
+        cmd = cmdChannel:pop()
+    end
+
+    -- Decode ahead if playing and not at EOF
+    if state == "playing" and not eof then
+        local buf = recycleChannel:pop()
+        if buf then
+            local pts = decodeOneFrame(buf)
+            if pts then
+                frameChannel:push("frame")
+                frameChannel:push(pts)
+                frameChannel:push(buf)
+            else
+                recycleChannel:push(buf)
+                if eof then
+                    frameChannel:push("eof")
+                end
+            end
+        else
+            love.timer.sleep(0.001)
+        end
+    else
+        love.timer.sleep(0.005)
+    end
+end

--- a/lib/video/depth_shaders.lua
+++ b/lib/video/depth_shaders.lua
@@ -1,0 +1,155 @@
+local DepthFX = {}
+
+-- Pass 1: Estimate depth from multiple visual cues
+DepthFX.estimate = love.graphics.newShader([[
+	extern float _darkChannelWeight;
+	extern float _saturationWeight;
+	extern float _blueShiftWeight;
+	extern float _sharpnessWeight;
+	extern float _verticalWeight;
+	extern vec2 _texelSize;
+
+	float luminance(vec3 c) {
+		return dot(c, vec3(0.299, 0.587, 0.114));
+	}
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec4 pixel = Texel(tex, tc);
+		vec3 rgb = pixel.rgb;
+		float depth = 0.0;
+		float totalWeight = 0.001;
+
+		// Dark channel prior: min(R,G,B) over a local patch
+		// Low values = hazy/distant
+		if (_darkChannelWeight > 0.0) {
+			float darkMin = 1.0;
+			for (int dx = -1; dx <= 1; dx++) {
+				for (int dy = -1; dy <= 1; dy++) {
+					vec3 s = Texel(tex, tc + vec2(float(dx), float(dy)) * _texelSize * 3.0).rgb;
+					darkMin = min(darkMin, min(s.r, min(s.g, s.b)));
+				}
+			}
+			// High dark channel = close, low = far
+			depth += (1.0 - darkMin) * _darkChannelWeight;
+			totalWeight += _darkChannelWeight;
+		}
+
+		// Saturation: low saturation = distant (atmospheric desaturation)
+		if (_saturationWeight > 0.0) {
+			float maxC = max(rgb.r, max(rgb.g, rgb.b));
+			float minC = min(rgb.r, min(rgb.g, rgb.b));
+			float sat = (maxC > 0.001) ? (maxC - minC) / maxC : 0.0;
+			// High saturation = close
+			depth += sat * _saturationWeight;
+			totalWeight += _saturationWeight;
+		}
+
+		// Blue shift: distant objects are more blue
+		if (_blueShiftWeight > 0.0) {
+			float blueExcess = rgb.b - (rgb.r + rgb.g) * 0.5;
+			float blueDepth = 1.0 - clamp(blueExcess * 2.0 + 0.5, 0.0, 1.0);
+			depth += blueDepth * _blueShiftWeight;
+			totalWeight += _blueShiftWeight;
+		}
+
+		// Local sharpness via Laplacian: sharp = close
+		if (_sharpnessWeight > 0.0) {
+			float center = luminance(rgb) * 4.0;
+			float neighbors = luminance(Texel(tex, tc + vec2(_texelSize.x, 0.0)).rgb)
+			               + luminance(Texel(tex, tc - vec2(_texelSize.x, 0.0)).rgb)
+			               + luminance(Texel(tex, tc + vec2(0.0, _texelSize.y)).rgb)
+			               + luminance(Texel(tex, tc - vec2(0.0, _texelSize.y)).rgb);
+			float laplacian = abs(center - neighbors);
+			depth += clamp(laplacian * 5.0, 0.0, 1.0) * _sharpnessWeight;
+			totalWeight += _sharpnessWeight;
+		}
+
+		// Vertical position: higher in frame = further
+		if (_verticalWeight > 0.0) {
+			depth += (1.0 - tc.y) * _verticalWeight;
+			totalWeight += _verticalWeight;
+		}
+
+		depth /= totalWeight;
+		return vec4(depth, depth, depth, 1.0);
+	}
+]])
+
+-- Pass 2: Two-pass separable Gaussian blur for smooth depth map
+DepthFX.blurH = love.graphics.newShader([[
+	extern vec2 _texelSize;
+	extern float _sigma;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec4 sum = vec4(0.0);
+		float total = 0.0;
+		int r = int(_sigma * 3.0);
+		float s2 = _sigma * _sigma * 2.0;
+		for (int i = -r; i <= r; i++) {
+			float w = exp(-float(i*i) / s2);
+			sum += Texel(tex, tc + vec2(float(i) * _texelSize.x, 0.0)) * w;
+			total += w;
+		}
+		return sum / total;
+	}
+]])
+
+DepthFX.blurV = love.graphics.newShader([[
+	extern vec2 _texelSize;
+	extern float _sigma;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec4 sum = vec4(0.0);
+		float total = 0.0;
+		int r = int(_sigma * 3.0);
+		float s2 = _sigma * _sigma * 2.0;
+		for (int i = -r; i <= r; i++) {
+			float w = exp(-float(i*i) / s2);
+			sum += Texel(tex, tc + vec2(0.0, float(i) * _texelSize.y)) * w;
+			total += w;
+		}
+		return sum / total;
+	}
+]])
+
+-- Pass 3: Parallax displacement using depth map
+DepthFX.displace = love.graphics.newShader([[
+	extern Image _depthMap;
+	extern vec2 _cameraOffset;
+	extern float _displaceStrength;
+	extern float _dofAmount;
+	extern vec2 _texelSize;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		float depth = Texel(_depthMap, tc).r;
+
+		// Parallax: displace based on depth and camera offset
+		// Close objects (depth~1) move more, far objects (depth~0) move less
+		vec2 offset = _cameraOffset * depth * _displaceStrength;
+		vec2 displaced_tc = clamp(tc + offset, vec2(0.0), vec2(1.0));
+		vec4 pixel = Texel(tex, displaced_tc);
+
+		// Depth-of-field: blur distant objects
+		if (_dofAmount > 0.0) {
+			float blur = (1.0 - depth) * _dofAmount;
+			int r = int(blur * 4.0);
+			if (r > 0) {
+				vec4 sum = pixel;
+				float total = 1.0;
+				for (int dx = -r; dx <= r; dx++) {
+					for (int dy = -r; dy <= r; dy++) {
+						if (dx == 0 && dy == 0) continue;
+						float w = 1.0 / (1.0 + float(dx*dx + dy*dy));
+						sum += Texel(tex, displaced_tc + vec2(float(dx), float(dy)) * _texelSize * blur) * w;
+						total += w;
+					}
+				}
+				pixel = sum / total;
+			}
+		}
+
+		return pixel;
+	}
+]])
+
+return DepthFX

--- a/lib/video/ffmpeg_ffi.lua
+++ b/lib/video/ffmpeg_ffi.lua
@@ -132,6 +132,9 @@ ffi.cdef[[
     void                av_frame_free(AVFrame **frame);
     void                av_frame_unref(AVFrame *frame);
     int64_t             av_rescale_q(int64_t a, AVRational bq, AVRational cq);
+    void                av_log_set_level(int level);
+    int                 av_opt_set(void *obj, const char *name, const char *val, int search_flags);
+    int                 av_opt_get_int(void *obj, const char *name, int search_flags, int64_t *out_val);
 
     // --- swscale functions ---
     SwsContext         *sws_getContext(int srcW, int srcH, int srcFormat,
@@ -153,5 +156,9 @@ M.AVERROR_EOF          = -541478725   -- FFERRTAG('E','O','F',' ')
 M.AVERROR_EAGAIN       = -11          -- AVERROR(EAGAIN)
 M.AV_TIME_BASE         = 1000000     -- microseconds
 M.AV_NOPTS_VALUE       = 0x8000000000000000LL
+M.AV_LOG_FATAL         = 8
+M.AV_LOG_ERROR         = 16
+M.AV_LOG_WARNING       = 24
+M.AV_LOG_QUIET         = -8
 
 return M

--- a/lib/video/ffmpeg_ffi.lua
+++ b/lib/video/ffmpeg_ffi.lua
@@ -1,0 +1,157 @@
+local ffi = require("ffi")
+
+local M = {}
+
+-- Load DLLs in dependency order (avutil first, then codecs, then format/scale)
+local dynlib = "dynlib/"
+if ffi.os == "Linux" then
+    M.avutil     = ffi.load(dynlib .. "libavutil.so")
+    M.swresample = ffi.load(dynlib .. "libswresample.so")
+    M.avcodec    = ffi.load(dynlib .. "libavcodec.so")
+    M.avformat   = ffi.load(dynlib .. "libavformat.so")
+    M.swscale    = ffi.load(dynlib .. "libswscale.so")
+elseif ffi.os == "OSX" then
+    M.avutil     = ffi.load(dynlib .. "libavutil.dylib")
+    M.swresample = ffi.load(dynlib .. "libswresample.dylib")
+    M.avcodec    = ffi.load(dynlib .. "libavcodec.dylib")
+    M.avformat   = ffi.load(dynlib .. "libavformat.dylib")
+    M.swscale    = ffi.load(dynlib .. "libswscale.dylib")
+else
+    M.avutil     = ffi.load(dynlib .. "avutil-60")
+    M.swresample = ffi.load(dynlib .. "swresample-6")
+    M.avcodec    = ffi.load(dynlib .. "avcodec-62")
+    M.avformat   = ffi.load(dynlib .. "avformat-62")
+    M.swscale    = ffi.load(dynlib .. "swscale-9")
+end
+
+-- Struct definitions (FFmpeg 7.x / avutil-60, avcodec-62, avformat-62)
+ffi.cdef[[
+    // --- Primitives ---
+    typedef struct { int num; int den; } AVRational;
+
+    // --- Opaque types ---
+    typedef struct AVCodecContext AVCodecContext;
+    typedef struct AVCodec AVCodec;
+    typedef struct SwsContext SwsContext;
+
+    // --- AVCodecParameters (fields up to width/height) ---
+    typedef struct AVCodecParameters {
+        int          codec_type;           // enum AVMediaType
+        int          codec_id;             // enum AVCodecID
+        uint32_t     codec_tag;
+        int          _pad0;
+        uint8_t     *extradata;
+        int          extradata_size;
+        int          _pad1;
+        void        *coded_side_data;
+        int          nb_coded_side_data;
+        int          format;
+        int64_t      bit_rate;
+        int          bits_per_coded_sample;
+        int          bits_per_raw_sample;
+        int          profile;
+        int          level;
+        int          width;
+        int          height;
+    } AVCodecParameters;
+
+    // --- AVStream (fields up to time_base) ---
+    typedef struct AVStream {
+        const void          *av_class;
+        int                  index;
+        int                  id;
+        AVCodecParameters   *codecpar;
+        void                *priv_data;
+        AVRational           time_base;
+    } AVStream;
+
+    // --- AVFormatContext (fields up to duration) ---
+    typedef struct AVFormatContext {
+        const void   *av_class;
+        const void   *iformat;
+        const void   *oformat;
+        void         *priv_data;
+        void         *pb;
+        int           ctx_flags;
+        unsigned int  nb_streams;
+        AVStream    **streams;
+        char         *url;
+        int64_t       start_time;
+        int64_t       duration;
+    } AVFormatContext;
+
+    // --- AVPacket (fields up to stream_index) ---
+    typedef struct AVPacket {
+        void        *buf;
+        int64_t      pts;
+        int64_t      dts;
+        uint8_t     *data;
+        int          size;
+        int          stream_index;
+        int          flags;
+    } AVPacket;
+
+    // --- AVFrame (FFmpeg 7.x layout — key_frame removed) ---
+    typedef struct AVFrame {
+        uint8_t     *data[8];
+        int          linesize[8];
+        uint8_t    **extended_data;
+        int          width;
+        int          height;
+        int          nb_samples;
+        int          format;
+        int          pict_type;
+        int          _pad0;
+        AVRational   sample_aspect_ratio;
+        int64_t      pts;
+    } AVFrame;
+
+    // --- avformat functions ---
+    int           avformat_open_input(AVFormatContext **ps, const char *url, const void *fmt, void **options);
+    int           avformat_find_stream_info(AVFormatContext *ic, void **options);
+    void          avformat_close_input(AVFormatContext **s);
+    int           av_find_best_stream(AVFormatContext *ic, int type, int wanted_stream_nb, int related_stream, const AVCodec **decoder_ret, int flags);
+    int           av_read_frame(AVFormatContext *s, AVPacket *pkt);
+    int           av_seek_frame(AVFormatContext *s, int stream_index, int64_t timestamp, int flags);
+
+    // --- avcodec functions (includes packet API) ---
+    const AVCodec      *avcodec_find_decoder(int id);
+    AVCodecContext     *avcodec_alloc_context3(const AVCodec *codec);
+    void                avcodec_free_context(AVCodecContext **avctx);
+    int                 avcodec_parameters_to_context(AVCodecContext *codec, const AVCodecParameters *par);
+    int                 avcodec_open2(AVCodecContext *avctx, const AVCodec *codec, void **options);
+    int                 avcodec_send_packet(AVCodecContext *avctx, const AVPacket *avpkt);
+    int                 avcodec_receive_frame(AVCodecContext *avctx, AVFrame *frame);
+    void                avcodec_flush_buffers(AVCodecContext *avctx);
+    AVPacket           *av_packet_alloc(void);
+    void                av_packet_free(AVPacket **pkt);
+    void                av_packet_unref(AVPacket *pkt);
+
+    // --- avutil functions ---
+    AVFrame            *av_frame_alloc(void);
+    void                av_frame_free(AVFrame **frame);
+    void                av_frame_unref(AVFrame *frame);
+    int64_t             av_rescale_q(int64_t a, AVRational bq, AVRational cq);
+
+    // --- swscale functions ---
+    SwsContext         *sws_getContext(int srcW, int srcH, int srcFormat,
+                                       int dstW, int dstH, int dstFormat,
+                                       int flags, void *srcFilter, void *dstFilter, const double *param);
+    int                 sws_scale(SwsContext *c,
+                                  const uint8_t *const srcSlice[], const int srcStride[],
+                                  int srcSliceY, int srcSliceH,
+                                  uint8_t *const dst[], const int dstStride[]);
+    void                sws_freeContext(SwsContext *swsContext);
+]]
+
+-- Constants
+M.AVMEDIA_TYPE_VIDEO   = 0
+M.AV_PIX_FMT_RGBA     = 26
+M.SWS_BILINEAR        = 2
+M.AVSEEK_FLAG_BACKWARD = 1
+M.AVERROR_EOF          = -541478725   -- FFERRTAG('E','O','F',' ')
+M.AVERROR_EAGAIN       = -11          -- AVERROR(EAGAIN)
+M.AV_TIME_BASE         = 1000000     -- microseconds
+M.AV_NOPTS_VALUE       = 0x8000000000000000LL
+
+return M

--- a/lib/video/glitch_shaders.lua
+++ b/lib/video/glitch_shaders.lua
@@ -1,0 +1,89 @@
+local GlitchFX = {}
+
+GlitchFX.blockDisplace = love.graphics.newShader([[
+	extern float _intensity;
+	extern float _time;
+	extern float _blockSize;
+
+	float hash(vec2 p) {
+		return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+	}
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec2 block = floor(tc * _blockSize) / _blockSize;
+		float h = hash(block + floor(_time * 2.0));
+		float trigger = step(1.0 - _intensity * 0.3, h);
+		float dx = (hash(block + vec2(0.5, 0.0)) - 0.5) * _intensity * 0.15 * trigger;
+		float dy = (hash(block + vec2(0.0, 0.5)) - 0.5) * _intensity * 0.15 * trigger;
+		return Texel(tex, clamp(tc + vec2(dx, dy), vec2(0.0), vec2(1.0)));
+	}
+]])
+
+GlitchFX.channelShift = love.graphics.newShader([[
+	extern float _intensity;
+	extern float _time;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		float shift = _intensity * 0.02;
+		float t = sin(_time * 3.0) * shift;
+		float r = Texel(tex, tc + vec2(t, 0.0)).r;
+		float g = Texel(tex, tc).g;
+		float b = Texel(tex, tc - vec2(t, 0.0)).b;
+		float a = Texel(tex, tc).a;
+		return vec4(r, g, b, a);
+	}
+]])
+
+
+GlitchFX.quantize = love.graphics.newShader([[
+	extern float _intensity;
+	extern float _time;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec4 pixel = Texel(tex, tc);
+		float levels = max(2.0, 256.0 - _intensity * 500.0);
+		pixel.rgb = floor(pixel.rgb * levels + 0.5) / levels;
+		return pixel;
+	}
+]])
+
+GlitchFX.hSmear = love.graphics.newShader([[
+	extern float _intensity;
+	extern float _time;
+	extern float _threshold;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec4 pixel = Texel(tex, tc);
+		float luma = dot(pixel.rgb, vec3(0.299, 0.587, 0.114));
+
+		if (luma > _threshold) {
+			float sortOffset = _intensity * 0.25 * (luma - _threshold);
+			vec2 sorted_tc = vec2(tc.x + sortOffset, tc.y);
+			pixel = Texel(tex, clamp(sorted_tc, vec2(0.0), vec2(1.0)));
+		}
+		return pixel;
+	}
+]])
+
+GlitchFX.frameEcho = love.graphics.newShader([[
+	extern float _intensity;
+	extern float _time;
+	extern Image _prevFrame;
+	extern float _hasPrev;
+
+	vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+		vec4 current = Texel(tex, tc);
+		if (_hasPrev < 0.5) return current;
+
+		float displaceAmt = _intensity * 0.03;
+		vec2 offset = vec2(
+			sin(_time * 1.7 + tc.y * 5.0) * displaceAmt,
+			cos(_time * 2.3 + tc.x * 5.0) * displaceAmt
+		);
+		vec4 prev = Texel(_prevFrame, tc + offset);
+		float blend = _intensity * 0.5;
+		return mix(current, prev, blend);
+	}
+]])
+
+return GlitchFX

--- a/lib/video/video_sampler.lua
+++ b/lib/video/video_sampler.lua
@@ -17,8 +17,11 @@ function VideoSampler:new()
     o.height = 0
     o.duration = 0
     o.frameDuration = 1 / 30
+    o.bendMode = "off"
     o.currentPts = -1
     o.currentBuf = nil
+    o.heldBuf = nil
+    o.heldPts = nil
     return o
 end
 
@@ -95,6 +98,20 @@ end
 function VideoSampler:_consumeFrames()
     local bestPts = nil
     local bestBuf = nil
+    local bending = self.bendMode and self.bendMode ~= "off"
+
+    -- In bend mode: skip PTS logic, just show the latest frame immediately
+    -- In normal mode: respect playhead position
+    if not bending and self.heldBuf then
+        if self.heldPts <= self.position + self.frameDuration then
+            bestPts = self.heldPts
+            bestBuf = self.heldBuf
+            self.heldBuf = nil
+            self.heldPts = nil
+        else
+            return
+        end
+    end
 
     while self.frameChannel:getCount() > 0 do
         local msg = self.frameChannel:pop()
@@ -102,16 +119,19 @@ function VideoSampler:_consumeFrames()
             local pts = self.frameChannel:demand()
             local buf = self.frameChannel:demand()
 
-            if bestBuf then
-                self.recycleChannel:push(bestBuf)
-            end
-
-            if pts <= self.position + self.frameDuration then
+            if bending then
+                -- Bend mode: always take the latest frame, no PTS gating
+                if bestBuf then self.recycleChannel:push(bestBuf) end
+                bestPts = pts
+                bestBuf = buf
+            elseif pts <= self.position + self.frameDuration then
+                if bestBuf then self.recycleChannel:push(bestBuf) end
                 bestPts = pts
                 bestBuf = buf
             else
-                bestPts = pts
-                bestBuf = buf
+                if self.heldBuf then self.recycleChannel:push(self.heldBuf) end
+                self.heldPts = pts
+                self.heldBuf = buf
                 break
             end
         elseif msg == "flush" then
@@ -119,6 +139,11 @@ function VideoSampler:_consumeFrames()
                 self.recycleChannel:push(bestBuf)
                 bestBuf = nil
                 bestPts = nil
+            end
+            if self.heldBuf then
+                self.recycleChannel:push(self.heldBuf)
+                self.heldBuf = nil
+                self.heldPts = nil
             end
         elseif msg == "eof" then
             self.eof = true
@@ -160,6 +185,11 @@ function VideoSampler:seek(seconds)
     if self.state ~= "open" then return end
     self.position = math.max(0, seconds)
     self.eof = false
+    if self.heldBuf then
+        self.recycleChannel:push(self.heldBuf)
+        self.heldBuf = nil
+        self.heldPts = nil
+    end
     self.cmdChannel:push("seek")
     self.cmdChannel:push(self.position)
     self.cmdChannel:push("play")
@@ -167,15 +197,26 @@ end
 
 function VideoSampler:setSpeed(speed)
     self.speed = speed
-    if self.state == "open" then
-        self.cmdChannel:push("speed")
-        self.cmdChannel:push(speed)
-    end
 end
 
 function VideoSampler:setLoopPoints(loopStart, loopEnd)
     self.loopStart = loopStart or 0
     self.loopEnd = loopEnd
+end
+
+function VideoSampler:setBendMode(mode)
+    if self.state ~= "open" then return end
+    if mode ~= self.bendMode then
+        self.bendMode = mode
+        self.cmdChannel:push("bend_mode")
+        self.cmdChannel:push(mode)
+    end
+end
+
+function VideoSampler:setBendIntensity(intensity)
+    if self.state ~= "open" then return end
+    self.cmdChannel:push("bend_intensity")
+    self.cmdChannel:push(intensity)
 end
 
 function VideoSampler:update(dt)
@@ -201,6 +242,19 @@ function VideoSampler:update(dt)
             self.position = self.loopStart
             self:seek(self.position)
             return
+        end
+
+        -- Reverse playback: decode thread only goes forward, so we must
+        -- seek to each new position when playing backwards.
+        if self.speed < 0 then
+            self.cmdChannel:push("seek")
+            self.cmdChannel:push(self.position)
+            self.cmdChannel:push("play")
+            if self.heldBuf then
+                self.recycleChannel:push(self.heldBuf)
+                self.heldBuf = nil
+                self.heldPts = nil
+            end
         end
     end
 

--- a/lib/video/video_sampler.lua
+++ b/lib/video/video_sampler.lua
@@ -1,0 +1,234 @@
+local ffi = require("ffi")
+
+local POOL_SIZE = 8
+
+local VideoSampler = {}
+VideoSampler.__index = VideoSampler
+
+function VideoSampler:new()
+    local o = setmetatable({}, self)
+    o.state = "closed"
+    o.position = 0
+    o.speed = 1.0
+    o.loopStart = 0
+    o.loopEnd = nil
+    o.playing = false
+    o.width = 0
+    o.height = 0
+    o.duration = 0
+    o.frameDuration = 1 / 30
+    o.currentPts = -1
+    o.currentBuf = nil
+    return o
+end
+
+function VideoSampler:open(path)
+    if self.state ~= "closed" then self:close() end
+
+    self.cmdChannel = love.thread.newChannel()
+    self.frameChannel = love.thread.newChannel()
+    self.recycleChannel = love.thread.newChannel()
+
+    self.thread = love.thread.newThread("lib/video/decode_thread.lua")
+    local sourcePath = love.filesystem.getSource()
+    self.thread:start(sourcePath, self.cmdChannel, self.frameChannel, self.recycleChannel)
+
+    self.cmdChannel:push("open")
+    self.cmdChannel:push(path)
+
+    -- Wait for info response
+    local response = self.frameChannel:demand(5)
+    if response == "error" then
+        local msg = self.frameChannel:demand()
+        logError("VideoSampler: " .. msg)
+        self:close()
+        return false
+    end
+    if response ~= "info" then
+        logError("VideoSampler: unexpected response: " .. tostring(response))
+        self:close()
+        return false
+    end
+
+    self.width = self.frameChannel:demand()
+    self.height = self.frameChannel:demand()
+    self.duration = self.frameChannel:demand()
+    self.frameDuration = self.frameChannel:demand()
+    local frameSize = self.width * self.height * 4
+
+    -- Create frame pool
+    self.pool = {}
+    for i = 1, POOL_SIZE do
+        local buf = love.data.newByteData(frameSize)
+        self.pool[i] = buf
+        self.recycleChannel:push(buf)
+    end
+
+    -- Create persistent ImageData and Image for GPU upload
+    self.imageData = love.image.newImageData(self.width, self.height, "rgba8")
+    self.imageDataPtr = ffi.cast("uint8_t*", self.imageData:getFFIPointer())
+    self.image = love.graphics.newImage(self.imageData)
+    self.frameSize = frameSize
+
+    self.state = "open"
+    self.position = 0
+    self.currentPts = -1
+    self.currentBuf = nil
+
+    logInfo("VideoSampler: opened " .. path ..
+        " (" .. self.width .. "x" .. self.height ..
+        ", " .. string.format("%.1f", self.duration) .. "s)")
+    return true
+end
+
+function VideoSampler:_drainFrames()
+    while self.frameChannel:getCount() > 0 do
+        local msg = self.frameChannel:pop()
+        if msg == "frame" then
+            local pts = self.frameChannel:demand()
+            local buf = self.frameChannel:demand()
+            self.recycleChannel:push(buf)
+        end
+    end
+end
+
+function VideoSampler:_consumeFrames()
+    local bestPts = nil
+    local bestBuf = nil
+
+    while self.frameChannel:getCount() > 0 do
+        local msg = self.frameChannel:pop()
+        if msg == "frame" then
+            local pts = self.frameChannel:demand()
+            local buf = self.frameChannel:demand()
+
+            if bestBuf then
+                self.recycleChannel:push(bestBuf)
+            end
+
+            if pts <= self.position + self.frameDuration then
+                bestPts = pts
+                bestBuf = buf
+            else
+                bestPts = pts
+                bestBuf = buf
+                break
+            end
+        elseif msg == "flush" then
+            if bestBuf then
+                self.recycleChannel:push(bestBuf)
+                bestBuf = nil
+                bestPts = nil
+            end
+        elseif msg == "eof" then
+            self.eof = true
+        end
+    end
+
+    if bestBuf then
+        local srcPtr = ffi.cast("const uint8_t*", bestBuf:getFFIPointer())
+        ffi.copy(self.imageDataPtr, srcPtr, self.frameSize)
+        self.image:replacePixels(self.imageData)
+        self.currentPts = bestPts
+
+        if self.currentBuf then
+            self.recycleChannel:push(self.currentBuf)
+        end
+        self.currentBuf = bestBuf
+    end
+end
+
+function VideoSampler:play()
+    if self.state ~= "open" then return end
+    self.playing = true
+    self.eof = false
+    self.cmdChannel:push("play")
+end
+
+function VideoSampler:pause()
+    if self.state ~= "open" then return end
+    self.playing = false
+    self.cmdChannel:push("pause")
+end
+
+function VideoSampler:stop()
+    self:pause()
+    self:seek(0)
+end
+
+function VideoSampler:seek(seconds)
+    if self.state ~= "open" then return end
+    self.position = math.max(0, seconds)
+    self.eof = false
+    self.cmdChannel:push("seek")
+    self.cmdChannel:push(self.position)
+    self.cmdChannel:push("play")
+end
+
+function VideoSampler:setSpeed(speed)
+    self.speed = speed
+    if self.state == "open" then
+        self.cmdChannel:push("speed")
+        self.cmdChannel:push(speed)
+    end
+end
+
+function VideoSampler:setLoopPoints(loopStart, loopEnd)
+    self.loopStart = loopStart or 0
+    self.loopEnd = loopEnd
+end
+
+function VideoSampler:update(dt)
+    if self.state ~= "open" then return end
+
+    if self.playing then
+        self.position = self.position + dt * self.speed
+
+        local effectiveEnd = self.loopEnd or self.duration
+        if effectiveEnd > 0 then
+            if self.speed >= 0 and self.position >= effectiveEnd then
+                self.position = self.loopStart
+                self:seek(self.position)
+                return
+            elseif self.speed < 0 and self.position <= self.loopStart then
+                self.position = effectiveEnd
+                self:seek(self.position)
+                return
+            end
+        end
+
+        if self.eof and self.speed >= 0 then
+            self.position = self.loopStart
+            self:seek(self.position)
+            return
+        end
+    end
+
+    self:_consumeFrames()
+end
+
+function VideoSampler:getImage()
+    return self.image
+end
+
+function VideoSampler:close()
+    if self.thread then
+        self.cmdChannel:push("quit")
+        self.thread:wait()
+        self.thread = nil
+    end
+    if self.currentBuf then
+        self.currentBuf = nil
+    end
+    self.pool = nil
+    self.image = nil
+    self.imageData = nil
+    self.imageDataPtr = nil
+    self.cmdChannel = nil
+    self.frameChannel = nil
+    self.recycleChannel = nil
+    self.state = "closed"
+    self.playing = false
+end
+
+return VideoSampler

--- a/main.lua
+++ b/main.lua
@@ -41,8 +41,8 @@ cfgCommands = lovjRequire("cfg/cfg_commands")
 -- Initialize Spout support
 if (cfgSpout.enable and
 	love.system.getOS() == "Windows" and
-	love.filesystem.getInfo("SpoutLibrary.dll") and
-	love.filesystem.getInfo("SpoutWrapper.dll")) then
+	love.filesystem.getInfo("dynlib/SpoutLibrary.dll") and
+	love.filesystem.getInfo("dynlib/SpoutWrapper.dll")) then
 	spout = lovjRequire("lib/spout")
 else
 	spout = lovjRequire("lib/stubs/spout-stub")
@@ -111,7 +111,7 @@ function bindPatchSlot(slot_idx)
 		get = function() return slot.patch end,
 		set = function(p) slot.patch = p end,
 		build = function(newModule)
-			newModule.init(slot_idx, globalSettings, slot.shaderext)
+			newModule:init(slot_idx, globalSettings, slot.shaderext)
 			wireParamNotifications(slot_idx, newModule)
 			return newModule
 		end,
@@ -206,9 +206,6 @@ function love.draw()
 	drawingUtils.clearCanvas(downMixCanvas)
 	drawingUtils.clearCanvas(nil)
 
-	-- Draw all patches stacked. On per-patch failure we keep the instance
-	-- in place (no fallback swap) — the error is visible via the banner,
-	-- and the next successful reload will clear it.
 	for i=1, #patchSlots do
 		local success, canvas = errorHandler.safePatchCall(i, "draw")
 		if success and canvas then
@@ -225,7 +222,6 @@ function love.draw()
 	main_spout_sender:SendCanvas(downMixCanvas, screen.Scaling.SpoutRatioX, screen.Scaling.SpoutRatioY)
 
 	love.graphics.setCanvas()
-	-- Banners are drawn by lick after love.draw returns.
 end
 
 
@@ -250,7 +246,7 @@ function love.update()
 	if globalSceneSequencer then globalSceneSequencer:tick() end
 	-- Copy baseValue → value for all params before modulators apply on top
 	for i = 1, #patchSlots do
-		if patchSlots[i].patch and patchSlots[i].patch.resources then
+		if patchSlots[i].patch and patchSlots[i].patch.resources and patchSlots[i].patch.resources.parameters then
 			patchSlots[i].patch.resources.parameters:resetModulation()
 		end
 		if patchSlots[i].shaderext then

--- a/main.lua
+++ b/main.lua
@@ -41,8 +41,7 @@ cfgCommands = lovjRequire("cfg/cfg_commands")
 -- Initialize Spout support
 if (cfgSpout.enable and
 	love.system.getOS() == "Windows" and
-	love.filesystem.getInfo("dynlib/SpoutLibrary.dll") and
-	love.filesystem.getInfo("dynlib/SpoutWrapper.dll")) then
+	love.filesystem.getInfo("dynlib/SpoutLibrary.dll")) then
 	spout = lovjRequire("lib/spout")
 else
 	spout = lovjRequire("lib/stubs/spout-stub")


### PR DESCRIPTION
## Summary

- **FFmpeg video sampler** — threaded decode via LuaJIT FFI (avformat/avcodec/swscale), ring buffer of 8 pre-decoded frames, any codec support (H.264, ProRes, Theora, etc.), varispeed, seeking, loop points
- **Databender** — packet-level video corruption: melt (I-frame skip), crush (I-frame corrupt), corrupt (block copy/shift), smash (P-frame repeat + I-frame skip). Decoder error recovery and throttle for stable playback
- **Glitch shaders** — blockDisplace, channelShift, quantize, hSmear, frameEcho. Chainable ping-pong pipeline
- **Depth FX** — multi-cue depth estimation (dark channel prior, saturation, blue shift, sharpness, vertical position) + Gaussian blur + parallax displacement + depth-of-field
- **Spout rewrite** — removed SpoutWrapper.dll dependency, calls SpoutLibrary.dll directly via C++ vtable from LuaJIT FFI. Fixes fullscreen toggle crash (#14)
- **Bug fixes** — demo23 shader leak (froze all patch switching), bindPatchSlot dot→colon syntax
- **Install scripts** — cross-platform Python installers for FFmpeg and Spout (replace .bat)
- **Demo29** — video databending + shader glitch showcase
- **Demo7/Demo11** — migrated to VideoSampler

## Test plan

- [ ] `python installFFmpeg.py` downloads FFmpeg DLLs to dynlib/
- [ ] `python installSpout.py` downloads SpoutLibrary.dll to dynlib/
- [ ] `love .` starts without errors
- [ ] Patch switching works reliably (demo23 shader leak fixed)
- [ ] Spout output survives fullscreen toggle (Ctrl+Enter)
- [ ] Demo29: video plays, databend modes produce glitch artifacts
- [ ] Demo29: shader glitch chain (blockDisplace, channelShift, etc.) works
- [ ] Demo29: depth parallax produces 2.5D effect with cameraX/Y
- [ ] Demo7/Demo11: VideoSampler plays .ogg video files